### PR TITLE
Add clearInteraction to mock service per test & add local pact writin…

### DIFF
--- a/lib/HttpClient.php
+++ b/lib/HttpClient.php
@@ -38,6 +38,9 @@ class HttpClient implements HttpRequest {
       else if (strtolower($method) == 'post') {
         $this->setOption(CURLOPT_POST, 1);
       }
+      else if (strtolower($method) == 'delete') {
+          $this->setOption( CURLOPT_CUSTOMREQUEST, 'DELETE');
+      }
       $this->setOption(CURLOPT_HTTPHEADER, ['Content-Type: application/json','X-Pact-Mock-Service: true']);
     }
   }
@@ -53,4 +56,5 @@ class HttpClient implements HttpRequest {
   public function getOption ($name) {
     return $this->options[$name];
   }
+
 }

--- a/lib/MockServiceRequests.php
+++ b/lib/MockServiceRequests.php
@@ -6,11 +6,23 @@ class MockServiceRequests {
   function __construct($httpClient = null) {
     $this->httpClient = is_null($httpClient) ? new HttpClient() : $httpClient;
   }
-  
+
+  public function clearInteractions($baseURL) {
+      $this->httpClient->setUrl($baseURL . '/interactions');
+      $this->httpClient->setMethod('DELETE');
+
+      $response = $this->httpClient->execute();
+      if (!$response) {
+          throw new \RuntimeException('Pact interaction clear failed');
+      }
+  }
+
   public function putInteractions($interactions, $baseURL) {
+
     $this->httpClient->setUrl($baseURL . '/interactions');
     $this->httpClient->setMethod('PUT');
     $this->httpClient->setBody(json_encode(['interactions' => $interactions]));
+
     $response = $this->httpClient->execute();
     if (!$response) {
       throw new \RuntimeException('Pact interaction setup failed');
@@ -30,9 +42,12 @@ class MockServiceRequests {
     $this->httpClient->setUrl($baseURL . '/pact');
     $this->httpClient->setMethod('POST');
     $this->httpClient->setBody(json_encode($pactDetails));
+
     $response = $this->httpClient->execute();
     if (!$response) {
       throw new \RuntimeException('Could not write the pact file');
     }
+
+    return $response;
   } 
 }


### PR DESCRIPTION
When comparing this framework to the Pact.Net port, clearInteractions was missing.

Furthermore, when testing, I had a docker image on a remote server. We should have functionality to write the pact file locally, rather than just remotely.